### PR TITLE
Fix Frozen-Flask package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask
 Flask_SQLAlchemy
 ollama
-Flask-Frozen
+Frozen-Flask


### PR DESCRIPTION
## Summary
- correct package name from Flask-Frozen to Frozen-Flask

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792bfb777c8333a78fe262114b17f6