### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 site.db
 __pycache__/
-docs/
 build/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ You can generate a static version of the site using Frozen-Flask:
 python freeze.py
 ```
 
-The static files are placed in the `docs/` directory. A GitHub Actions
-workflow (`.github/workflows/gh-pages.yml`) is provided to automatically
-freeze the site and publish it to the `gh-pages` branch so it can be served
-with GitHub Pages. Enable Pages for that branch in your repository settings.
+The script initializes the database tables if needed and then writes the
+generated HTML to the `docs/` directory.
+
+A GitHub Actions workflow (`.github/workflows/gh-pages.yml`) automatically
+freezes the site on every push to `main` and publishes the contents of `docs/`
+to the `gh-pages` branch. Enable GitHub Pages for that branch in the repository
+settings so the static site is available at `https://<username>.github.io/<repo>`.

--- a/app.py
+++ b/app.py
@@ -47,25 +47,25 @@ def index():
     return render_template("index.html", posts=posts)
 
 
-@app.route("/courses")
+@app.route("/courses/")
 def courses():
     courses = Course.query.all()
     return render_template("courses.html", courses=courses)
 
 
-@app.route("/courses/<int:course_id>")
+@app.route("/courses/<int:course_id>/")
 def course_detail(course_id):
     course = Course.query.get_or_404(course_id)
     return render_template("course_detail.html", course=course)
 
 
-@app.route("/certificate/<int:course_id>")
+@app.route("/certificate/<int:course_id>/")
 def certificate(course_id):
     course = Course.query.get_or_404(course_id)
     return render_template("certificate.html", course=course)
 
 
-@app.route("/admin", methods=["GET", "POST"])
+@app.route("/admin/", methods=["GET", "POST"])
 def admin():
     if request.method == "POST":
         action = request.form.get("action")

--- a/docs/admin/index.html
+++ b/docs/admin/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head><title>Admin</title></head>
+<body>
+<h1>Admin</h1>
+<form method="post">
+  <input type="hidden" name="action" value="blog">
+  <button type="submit">Generate Daily Blog Post</button>
+</form>
+<form method="post">
+  <input type="hidden" name="action" value="course">
+  Topic: <input type="text" name="topic">
+  Difficulty: <input type="text" name="difficulty" value="Beginner">
+  Prerequisites: <input type="text" name="prerequisites">
+  <button type="submit">Generate Course</button>
+</form>
+<a href="/">Home</a>
+</body>
+</html>

--- a/docs/courses/index.html
+++ b/docs/courses/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head><title>Courses</title></head>
+<body>
+<h1>Courses</h1>
+<ul>
+
+  <li>No courses yet.</li>
+
+</ul>
+<a href="/">Home</a>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head><title>Judaism Online</title></head>
+<body>
+<h1>Daily Blog</h1>
+
+  <p>No posts yet.</p>
+
+<a href="/courses/">Courses</a> |
+<a href="/admin/">Admin</a>
+</body>
+</html>

--- a/freeze.py
+++ b/freeze.py
@@ -1,4 +1,4 @@
-from app import app, Course
+from app import app, Course, create_tables
 from flask_frozen import Freezer
 
 app.config['FREEZER_DESTINATION'] = 'docs'
@@ -15,4 +15,6 @@ def certificate():
         yield {'course_id': course.id}
 
 if __name__ == '__main__':
+    with app.app_context():
+        create_tables()
     freezer.freeze()


### PR DESCRIPTION
## Summary
- make URLs end with `/` so Frozen-Flask creates `index.html`
- initialize DB tables during freezing
- commit generated docs and allow them in git
- document GitHub Pages workflow

## Testing
- `python -m py_compile app.py daily_post.py freeze.py`
- `python freeze.py`

------
https://chatgpt.com/codex/tasks/task_e_68794305f8c48333ab6b392bcf0ea519