### PR TITLE
Fix GitHub Pages routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ A GitHub Actions workflow (`.github/workflows/gh-pages.yml`) automatically
 freezes the site on every push to `main` and publishes the contents of `docs/`
 to the `gh-pages` branch. Enable GitHub Pages for that branch in the repository
 settings so the static site is available at `https://<username>.github.io/<repo>`.
+The freezer now produces **relative URLs** so the site works correctly when
+served from that sub-path. After generating or editing content locally, run
+`python freeze.py` and push the updated `docs/` directory to trigger the
+deployment workflow.

--- a/freeze.py
+++ b/freeze.py
@@ -4,7 +4,13 @@ from flask_frozen import Freezer
 import re
 
 app.config['FREEZER_DESTINATION'] = 'docs'
-app.config['FREEZER_IGNORE_URLS'] = [re.compile(r'/admin'), re.compile(r'/login'), re.compile(r'/logout')]
+app.config['FREEZER_IGNORE_URLS'] = [
+    re.compile(r'/admin'),
+    re.compile(r'/login'),
+    re.compile(r'/logout'),
+]
+# Use relative URLs so the site works when hosted from a subdirectory
+app.config['FREEZER_RELATIVE_URLS'] = True
 freezer = Freezer(app)
 
 @freezer.register_generator

--- a/index.html
+++ b/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <meta http-equiv="Refresh" content="0; url=docs/index.html" />
+  </head>
+  <body>
+    <p>Redirecting to <a href="docs/index.html">docs/index.html</a>...</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add an index.html redirect in the repo root so GitHub Pages shows the landing page
- generate relative URLs by configuring `FREEZER_RELATIVE_URLS`
- document the deployment step in the README

## Testing
- `python -m py_compile app.py freeze.py daily_post.py update_news.py`
- `python freeze.py`

------
https://chatgpt.com/codex/tasks/task_e_6879783cd8448333be02d12e07385f4f