### PR TITLE
Improve blog post generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ It uses the local Llama 3 model (via [Ollama](https://github.com/ollama/ollama))
 - Courses include difficulty levels and prerequisites.
 - Printable certificate page after completing a course.
 - News section populated from the JTA API (`update_news.py`).
+- Optional `update_site.py` script automates creating posts, freezing the site
+  and pushing updates to GitHub.
 
 ## Setup
 
@@ -29,6 +31,10 @@ It uses the local Llama 3 model (via [Ollama](https://github.com/ollama/ollama))
 5. (Optional) Fetch the latest news items:
    ```bash
    python update_news.py
+   ```
+6. (Optional) Automatically create posts, freeze the site and push updates:
+   ```bash
+   python update_site.py
    ```
 
 The application uses a SQLite database (`site.db`) created automatically on first run.
@@ -62,3 +68,10 @@ The freezer now produces **relative URLs** so the site works correctly when
 served from that sub-path. After generating or editing content locally, run
 `python freeze.py` and push the updated `docs/` directory to trigger the
 deployment workflow.
+
+`update_site.py` provides a simple way to automate this process locally. It
+creates new posts, freezes the site and pushes the result in a single command.
+
+Other static hosting platforms such as Netlify or Vercel can be used if you
+prefer. Any service capable of serving the generated `docs/` directory will
+work.

--- a/app.py
+++ b/app.py
@@ -70,8 +70,8 @@ def generate_text(prompt: str) -> str:
 NEWS_API_URL = "https://www.jta.org/wp-json/wp/v2/posts?per_page=5"
 
 
-def generate_blog_content() -> str:
-    """Create blog content using a random news topic when available."""
+def generate_blog_post() -> tuple[str, str]:
+    """Create a blog post and return a `(title, content)` tuple."""
     topic = None
     try:
         resp = requests.get(NEWS_API_URL, timeout=10)
@@ -86,14 +86,20 @@ def generate_blog_content() -> str:
     if topic:
         prompt = (
             f"Write a short blog post about Judaism inspired by this news topic: {topic}. "
-            f"Include today's date ({date}) in the text and do not mention the day of the week."
+            f"Include today's date ({date}) in the text and do not mention the day of the week. "
+            "Start with a concise title summarizing the post on the first line, followed by a blank line and then the body."
         )
     else:
         prompt = (
             f"Write a short blog post about an aspect of Judaism. "
-            f"Include today's date ({date}) in the text and do not mention the day of the week."
+            f"Include today's date ({date}) in the text and do not mention the day of the week. "
+            "Start with a concise title summarizing the post on the first line, followed by a blank line and then the body."
         )
-    return generate_text(prompt)
+    response = generate_text(prompt).strip()
+    lines = response.split("\n", 1)
+    title = lines[0].strip()
+    content = lines[1].strip() if len(lines) > 1 else ""
+    return title, content
 
 
 def create_tables():
@@ -189,8 +195,7 @@ def admin():
     if request.method == "POST":
         action = request.form.get("action")
         if action == "blog":
-            content = generate_blog_content()
-            title = content.split("\n")[0].strip()
+            title, content = generate_blog_post()
             post = BlogPost(title=title, content=content)
             db.session.add(post)
             db.session.commit()

--- a/daily_post.py
+++ b/daily_post.py
@@ -1,12 +1,11 @@
 """Script to generate a daily blog post using the local Llama 3 model."""
 
-from app import db, BlogPost, generate_blog_content
+from app import db, BlogPost, generate_blog_post
 
 
 def create_daily_posts(count: int = 2):
     for _ in range(count):
-        content = generate_blog_content()
-        title = content.split("\n")[0].strip()
+        title, content = generate_blog_post()
         post = BlogPost(title=title, content=content)
         db.session.add(post)
         db.session.commit()

--- a/update_site.py
+++ b/update_site.py
@@ -1,0 +1,20 @@
+import datetime
+import subprocess
+
+COMMANDS = [
+    ['python', 'daily_post.py'],
+    ['python', 'freeze.py'],
+]
+
+def run(cmd):
+    print('Running:', ' '.join(cmd))
+    subprocess.run(cmd, check=True)
+
+if __name__ == '__main__':
+    for cmd in COMMANDS:
+        run(cmd)
+    run(['git', 'add', 'docs'])
+    msg = f"Update site {datetime.date.today().isoformat()}"
+    run(['git', 'commit', '-m', msg])
+    run(['git', 'push'])
+


### PR DESCRIPTION
## Summary
- generate a short title and body separately when creating blog posts
- call new helper in admin interface and daily script
- add optional `update_site.py` for automating daily posts and pushes
- document new script and deployment tips in README

## Testing
- `python -m py_compile app.py daily_post.py update_site.py freeze.py update_news.py main.py`
- `pip install -r requirements.txt`
- `python freeze.py` *(fails: MissingURLGeneratorWarning)*
- `python update_site.py` *(fails: connection refused for ollama)*

------
https://chatgpt.com/codex/tasks/task_e_687992219f80833388d12a8458a138d7