### PR TITLE
Add full course HTML view

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It uses the local Llama 3 model (via [Ollama](https://github.com/ollama/ollama))
 - Admin interface to create new blog posts and courses on demand and edit page content.
 - Courses include difficulty levels and prerequisites.
 - Printable certificate page after completing a course.
+- Full course pages display all sections together using a modern accordion layout.
 - News section populated from the JTA API (`update_news.py`).
 - Optional `update_site.py` script automates creating posts, freezing the site
   and pushing updates to GitHub.

--- a/app.py
+++ b/app.py
@@ -272,6 +272,18 @@ def certificate(course_id):
     return render_template("certificate.html", course=course)
 
 
+@app.route("/courses/<int:course_id>/full/")
+def course_full(course_id):
+    """Display the entire course with all sections in one page."""
+    course = Course.query.get_or_404(course_id)
+    sections = (
+        CourseSection.query.filter_by(course_id=course_id)
+        .order_by(CourseSection.order)
+        .all()
+    )
+    return render_template("course_full.html", course=course, sections=sections)
+
+
 @app.route("/courses/<int:course_id>/section/<int:section_id>/", methods=["GET", "POST"])
 def course_section(course_id, section_id):
     course = Course.query.get_or_404(course_id)

--- a/freeze.py
+++ b/freeze.py
@@ -25,6 +25,12 @@ def certificate():
 
 
 @freezer.register_generator
+def course_full():
+    for course in Course.query.all():
+        yield {'course_id': course.id}
+
+
+@freezer.register_generator
 def course_section():
     for section in CourseSection.query.all():
         yield {'course_id': section.course_id, 'section_id': section.id}

--- a/templates/course_detail.html
+++ b/templates/course_detail.html
@@ -29,6 +29,7 @@
     {% if all_done %}
     <a class="btn btn-success mt-3" href="{{ url_for('certificate', course_id=course.id) }}">Get Certificate</a>
     {% endif %}
+    <a class="btn btn-outline-secondary mt-3" href="{{ url_for('course_full', course_id=course.id) }}">View Full Course</a>
   </div>
 </div>
 {% endblock %}

--- a/templates/course_full.html
+++ b/templates/course_full.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="mb-4">
+  <h1>{{ course.title }}</h1>
+  <div class="mb-3">{{ course.description|safe }}</div>
+  <h2 class="mt-4">Course Content</h2>
+  <div class="accordion" id="sections">
+  {% for s in sections %}
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="heading{{ loop.index }}">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ loop.index }}" aria-expanded="false" aria-controls="collapse{{ loop.index }}">
+          {{ loop.index }}. {{ s.title }}
+        </button>
+      </h2>
+      <div id="collapse{{ loop.index }}" class="accordion-collapse collapse" aria-labelledby="heading{{ loop.index }}" data-bs-parent="#sections">
+        <div class="accordion-body">
+          {{ s.content|safe }}
+          {% if s.question %}
+          <p class="fw-bold mt-3">{{ s.question }}</p>
+          <p class="text-muted">Correct answer: {{ s.answer }}</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  {% endfor %}
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow viewing full course content at `/courses/<id>/full/`
- render all sections in an accordion via new `course_full.html`
- link to full view from course detail page
- freeze now generates full course pages
- document the feature in README

## Testing
- `python -m py_compile app.py freeze.py update_site.py daily_post.py update_news.py main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a93f0b73c833389bd16d5ae3cabae