### PR TITLE
Improve AI course formatting with Markdown support

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from flask import (
 )
 from flask_sqlalchemy import SQLAlchemy
 import ollama
+from markdown import markdown
 import random
 import requests
 from werkzeug.utils import secure_filename
@@ -23,6 +24,13 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['UPLOAD_FOLDER'] = os.path.join('static', 'uploads')
 app.secret_key = os.environ.get('SECRET_KEY', 'secret')
 db = SQLAlchemy(app)
+
+
+# Markdown filter to render AI-generated text nicely
+@app.template_filter('markdown')
+def markdown_filter(text: str) -> str:
+    """Convert Markdown text to HTML."""
+    return markdown(text or '')
 
 
 class BlogPost(db.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask_SQLAlchemy
 ollama
 Frozen-Flask
 requests
+markdown

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -5,7 +5,7 @@
   <div class="mb-4">
     <h2>{{ post.title }}</h2>
     <p class="text-muted">{{ post.created_at.strftime('%B %d, %Y') }}</p>
-    <p>{{ post.content|safe }}</p>
+    <p>{{ post.content|markdown|safe }}</p>
   </div>
 {% else %}
   <p>No posts yet.</p>

--- a/templates/course_detail.html
+++ b/templates/course_detail.html
@@ -10,7 +10,7 @@
     <h1 class="card-title">{{ course.title }}</h1>
     <p class="card-text"><strong>Difficulty:</strong> {{ course.difficulty }}</p>
     <p class="card-text"><strong>Prerequisites:</strong> {{ course.prerequisites }}</p>
-    <p class="card-text">{{ course.description|safe }}</p>
+    <p class="card-text">{{ course.description|markdown|safe }}</p>
     {% if sections %}
     <h3>Sections</h3>
     <ul class="list-group">

--- a/templates/course_full.html
+++ b/templates/course_full.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="mb-4">
   <h1>{{ course.title }}</h1>
-  <div class="mb-3">{{ course.description|safe }}</div>
+  <div class="mb-3">{{ course.description|markdown|safe }}</div>
   <h2 class="mt-4">Course Content</h2>
   <div class="accordion" id="sections">
   {% for s in sections %}
@@ -14,7 +14,7 @@
       </h2>
       <div id="collapse{{ loop.index }}" class="accordion-collapse collapse" aria-labelledby="heading{{ loop.index }}" data-bs-parent="#sections">
         <div class="accordion-body">
-          {{ s.content|safe }}
+          {{ s.content|markdown|safe }}
           {% if s.question %}
           <p class="fw-bold mt-3">{{ s.question }}</p>
           <p class="text-muted">Correct answer: {{ s.answer }}</p>

--- a/templates/course_section.html
+++ b/templates/course_section.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="mb-4">
   <h1>{{ section.title }}</h1>
-  <div class="mb-3">{{ section.content|safe }}</div>
+  <div class="mb-3">{{ section.content|markdown|safe }}</div>
   {% if completed %}
   <p class="alert alert-success">Section completed.</p>
   <a class="btn btn-secondary" href="{{ url_for('course_detail', course_id=course.id) }}">Back to Course</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
   <div class="p-5 mb-4 bg-light rounded-3">
     <div class="container-fluid py-5">
       <h1 class="display-5 fw-bold">{{ page.title }}</h1>
-      <p class="col-md-8 fs-4">{{ page.content|safe }}</p>
+      <p class="col-md-8 fs-4">{{ page.content|markdown|safe }}</p>
     </div>
   </div>
 {% endblock %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
   <h1>{{ page.title }}</h1>
-  <div>{{ page.content|safe }}</div>
+  <div>{{ page.content|markdown|safe }}</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `markdown` package
- create a Jinja filter to convert Markdown text to HTML
- render course descriptions, sections, pages and posts with Markdown

## Testing
- `python -m py_compile app.py`
- `python -m py_compile daily_post.py freeze.py update_site.py update_news.py`
- `pip install markdown`

------
https://chatgpt.com/codex/tasks/task_e_687a9b4c5ea08333a7bd50b99b6ed892