### PR TITLE
Improve certificate flow and cleanup course pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -270,14 +270,23 @@ def course_detail(course_id):
     )
 
 
-@app.route("/certificate/<int:course_id>/")
+@app.route("/certificate/<int:course_id>/", methods=["GET", "POST"])
 def certificate(course_id):
     course = Course.query.get_or_404(course_id)
-    sections = CourseSection.query.filter_by(course_id=course_id).all()
+    sections = (
+        CourseSection.query.filter_by(course_id=course_id)
+        .order_by(CourseSection.order)
+        .all()
+    )
     completed = session.get("completed_sections", {}).get(str(course_id), [])
     if sections and not all(s.id in completed for s in sections):
         abort(403)
-    return render_template("certificate.html", course=course)
+    name = None
+    if request.method == "POST":
+        name = request.form.get("name", "").strip()
+    return render_template(
+        "certificate.html", course=course, sections=sections, name=name
+    )
 
 
 @app.route("/courses/<int:course_id>/full/")

--- a/templates/certificate.html
+++ b/templates/certificate.html
@@ -1,7 +1,23 @@
 {% extends 'base.html' %}
 {% block content %}
+{% if name %}
 <body onload="window.print()" class="p-5">
 <h1>Certificate of Completion</h1>
-<p>Congratulations on completing the course: {{ course.title }}</p>
+<p>Congratulations {{ name }} on completing the course: {{ course.title }}</p>
+<h2 class="mt-4">Course Sections</h2>
+<ul>
+  {% for s in sections %}
+  <li>{{ s.title }}</li>
+  {% endfor %}
+</ul>
 </body>
+{% else %}
+<form method="post">
+  <div class="mb-3">
+    <label for="name" class="form-label">Your Name</label>
+    <input class="form-control" id="name" name="name" placeholder="Your name">
+  </div>
+  <button class="btn btn-primary" type="submit">Generate Certificate</button>
+</form>
+{% endif %}
 {% endblock %}

--- a/templates/course_detail.html
+++ b/templates/course_detail.html
@@ -29,7 +29,6 @@
     {% if all_done %}
     <a class="btn btn-success mt-3" href="{{ url_for('certificate', course_id=course.id) }}">Get Certificate</a>
     {% endif %}
-    <a class="btn btn-outline-secondary mt-3" href="{{ url_for('course_full', course_id=course.id) }}">View Full Course</a>
   </div>
 </div>
 {% endblock %}

--- a/templates/course_full.html
+++ b/templates/course_full.html
@@ -3,7 +3,6 @@
 <div class="mb-4">
   <h1>{{ course.title }}</h1>
   <div class="mb-3">{{ course.description|markdown|safe }}</div>
-  <h2 class="mt-4">Course Content</h2>
   <div class="accordion" id="sections">
   {% for s in sections %}
     <div class="accordion-item">


### PR DESCRIPTION
## Summary
- remove extra *Course Content* heading from course pages
- drop the *View Full Course* link
- expand certificate page
  - prompt for name before displaying certificate
  - list completed course sections on the certificate
- update certificate route to handle POST and pass section info

## Testing
- `python -m py_compile app.py`
- `python freeze.py` *(fails: MissingURLGeneratorWarning)*

------
https://chatgpt.com/codex/tasks/task_e_687ab46c1630833393e353e9c31bfb15