### PR TITLE
Add user registration with encrypted data

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ It uses the local Llama 3 model (via [Ollama](https://github.com/ollama/ollama))
 
 The application uses a SQLite database (`site.db`) created automatically on first run.
 
+User accounts can be created via the `/register/` page. Only a username and password
+are required. An optional email can be supplied for newsletter updates and password
+recovery. Personal details are encrypted in the database using a key provided by the
+`ENCRYPT_KEY` environment variable (one will be generated automatically if not set).
+Certificates are free, though an optional $5 contribution can be recorded to help
+cover site costs.
+
 Placeholder images used by the templates can be replaced in `static/`:
 
 - `hero.jpg`

--- a/freeze.py
+++ b/freeze.py
@@ -8,6 +8,8 @@ app.config['FREEZER_IGNORE_URLS'] = [
     re.compile(r'/admin'),
     re.compile(r'/login'),
     re.compile(r'/logout'),
+    re.compile(r'/register'),
+    re.compile(r'/user'),
 ]
 # Use relative URLs so the site works when hosted from a subdirectory
 app.config['FREEZER_RELATIVE_URLS'] = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ollama
 Frozen-Flask
 requests
 markdown
+cryptography

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Admin</h1>
+<p><strong>Users:</strong> {{ user_count }} | <strong>Purchases:</strong> {{ purchase_count }} | <strong>Completed Courses:</strong> {{ completion_count }}</p>
+<p><strong>Recovery email:</strong> {{ admin_email }}</p>
 <form method="post" class="mb-3 show-spinner">
   <input type="hidden" name="action" value="blog">
   <button class="btn btn-primary" type="submit">Generate Blog Post</button>

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,13 +21,19 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('about') }}"><i class="fa-solid fa-circle-info me-1"></i>About</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('contact') }}"><i class="fa-solid fa-envelope me-1"></i>Contact</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('faq') }}"><i class="fa-solid fa-circle-question me-1"></i>FAQ</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('terms') }}"><i class="fa-solid fa-file-contract me-1"></i>Terms</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('news') }}"><i class="fa-solid fa-newspaper me-1"></i>News</a></li>
       </ul>
       {% if session.get('logged_in') %}
         <a class="btn btn-outline-secondary" href="{{ url_for('admin') }}"><i class="fa-solid fa-user-gear me-1"></i>Admin</a>
         <a class="btn btn-outline-secondary ms-2" href="{{ url_for('logout') }}"><i class="fa-solid fa-right-from-bracket me-1"></i>Logout</a>
       {% else %}
-        <a class="btn btn-outline-primary" href="{{ url_for('login') }}"><i class="fa-solid fa-right-to-bracket me-1"></i>Login</a>
+        {% if session.get('user_id') %}
+          <a class="btn btn-outline-secondary" href="{{ url_for('user_logout') }}"><i class="fa-solid fa-right-from-bracket me-1"></i>Logout</a>
+        {% else %}
+          <a class="btn btn-outline-primary" href="{{ url_for('user_login') }}"><i class="fa-solid fa-right-to-bracket me-1"></i>Login</a>
+          <a class="btn btn-outline-primary ms-2" href="{{ url_for('register') }}">Register</a>
+        {% endif %}
       {% endif %}
     </div>
   </div>

--- a/templates/certificate.html
+++ b/templates/certificate.html
@@ -17,7 +17,9 @@
     <label for="name" class="form-label">Your Name</label>
     <input class="form-control" id="name" name="name" placeholder="Your name">
   </div>
-  <button class="btn btn-primary" type="submit">Generate Certificate</button>
+  <p class="mb-2">Certificates are free. You may optionally contribute $5 to support the site.</p>
+  <button class="btn btn-primary me-2" type="submit">Generate Certificate</button>
+  <button class="btn btn-secondary" name="support" value="yes" type="submit">Support the Site</button>
 </form>
 {% endif %}
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 data-aos="fade-down">Register</h1>
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+<form method="post" data-aos="fade-up">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input class="form-control" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input class="form-control" type="password" name="password" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Confirm Password</label>
+    <input class="form-control" type="password" name="confirm" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Email (optional)</label>
+    <input class="form-control" name="email">
+  </div>
+  <button class="btn btn-primary" type="submit">Register</button>
+</form>
+{% endblock %}

--- a/templates/user_login.html
+++ b/templates/user_login.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 data-aos="fade-down">Login</h1>
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+<form method="post" data-aos="fade-up">
+  <div class="mb-3">
+    <input class="form-control" name="username" placeholder="Username">
+  </div>
+  <div class="mb-3">
+    <input class="form-control" type="password" name="password" placeholder="Password">
+  </div>
+  <button class="btn btn-primary" type="submit">Login</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add optional email registration and login for users
- encrypt personal data with Fernet
- create terms page and update navigation
- record optional certificate support payments
- display site statistics on admin page
- update docs and requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d441cba408333961f577dfcb19dda