### PR TITLE
Add email PDF certificate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It uses the local Llama 3 model (via [Ollama](https://github.com/ollama/ollama))
 - Admin interface to create new blog posts and courses on demand and edit page content.
 - Courses include difficulty levels and prerequisites.
 - Printable certificate page after completing a course.
+- Certificates can also be emailed as PDFs.
 - Full course pages display all sections together using a modern accordion layout.
 - News section populated from the JTA API (`update_news.py`).
 - Optional `update_site.py` script automates creating posts, freezing the site
@@ -46,6 +47,11 @@ recovery. Personal details are encrypted in the database using a key provided by
 `ENCRYPT_KEY` environment variable (one will be generated automatically if not set).
 Certificates are free, though an optional $5 contribution can be recorded to help
 cover site costs.
+
+To send PDF certificates via email, provide SMTP details using the `SMTP_SERVER`,
+`SMTP_PORT`, `SMTP_USER` and `SMTP_PASSWORD` environment variables. The sender
+address can be configured from the admin page or via the `ADMIN_EMAIL`
+environment variable.
 
 Placeholder images used by the templates can be replaced in `static/`:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Frozen-Flask
 requests
 markdown
 cryptography
+reportlab

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -2,7 +2,15 @@
 {% block content %}
 <h1>Admin</h1>
 <p><strong>Users:</strong> {{ user_count }} | <strong>Purchases:</strong> {{ purchase_count }} | <strong>Completed Courses:</strong> {{ completion_count }}</p>
-<p><strong>Recovery email:</strong> {{ admin_email }}</p>
+<p><strong>Certificate sender:</strong> {{ admin_email }}</p>
+<form method="post" class="mb-3">
+  <input type="hidden" name="action" value="update_setting">
+  <input type="hidden" name="key" value="admin_email">
+  <div class="input-group">
+    <input type="email" name="value" class="form-control" placeholder="Sender email" value="{{ admin_email }}">
+    <button class="btn btn-secondary" type="submit">Save</button>
+  </div>
+</form>
 <form method="post" class="mb-3 show-spinner">
   <input type="hidden" name="action" value="blog">
   <button class="btn btn-primary" type="submit">Generate Blog Post</button>

--- a/templates/certificate.html
+++ b/templates/certificate.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
-{% if name %}
+{% if sent %}
+<div class="alert alert-success">Certificate emailed to {{ name }}.</div>
+{% elif name %}
 <body onload="window.print()" class="p-5">
 <h1>Certificate of Completion</h1>
 <p>Congratulations {{ name }} on completing the course: {{ course.title }}</p>
@@ -16,6 +18,10 @@
   <div class="mb-3">
     <label for="name" class="form-label">Your Name</label>
     <input class="form-control" id="name" name="name" placeholder="Your name">
+  </div>
+  <div class="mb-3">
+    <label for="email" class="form-label">Email</label>
+    <input class="form-control" id="email" name="email" placeholder="you@example.com">
   </div>
   <p class="mb-2">Certificates are free. You may optionally contribute $5 to support the site.</p>
   <button class="btn btn-primary me-2" type="submit">Generate Certificate</button>


### PR DESCRIPTION
## Summary
- allow admin to configure sender email
- email PDF certificates using SMTP
- store site settings in database
- update certificate form for email
- document SMTP configuration in README

## Testing
- `python -m py_compile app.py`
- `python -m py_compile freeze.py`

------
https://chatgpt.com/codex/tasks/task_e_687d4d3a847c833399f1cb29577089f5