### PR TITLE
Add footer terms link and limit news retention

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,6 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('about') }}"><i class="fa-solid fa-circle-info me-1"></i>About</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('contact') }}"><i class="fa-solid fa-envelope me-1"></i>Contact</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('faq') }}"><i class="fa-solid fa-circle-question me-1"></i>FAQ</a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('terms') }}"><i class="fa-solid fa-file-contract me-1"></i>Terms</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('news') }}"><i class="fa-solid fa-newspaper me-1"></i>News</a></li>
       </ul>
       {% if session.get('logged_in') %}
@@ -41,6 +40,9 @@
 <div class="container">
   {% block content %}{% endblock %}
 </div>
+<footer class="text-center mt-4">
+  <a href="{{ url_for('terms') }}">Terms &amp; Disclaimer</a>
+</footer>
 <div id="loading-overlay" class="position-fixed top-0 start-0 w-100 h-100 d-none justify-content-center align-items-center" style="background: rgba(255,255,255,0.7); z-index: 1050;">
   <div class="spinner-border text-primary" role="status">
     <span class="visually-hidden">Loading...</span>

--- a/templates/news.html
+++ b/templates/news.html
@@ -3,7 +3,11 @@
 <h1 data-aos="fade-down">News</h1>
 <ul data-aos="fade-up">
 {% for item in items %}
-  <li><a href="{{ item.url }}" target="_blank">{{ item.title }}</a></li>
+  <li>
+    <small class="text-muted">{{ item.created_at.strftime('%Y-%m-%d') }}</small>
+    <br>
+    <a href="{{ item.url }}" target="_blank">{{ item.title }}</a>
+  </li>
 {% else %}
   <li>No news yet.</li>
 {% endfor %}

--- a/update_news.py
+++ b/update_news.py
@@ -16,6 +16,15 @@ def fetch_news():
         if not NewsItem.query.filter_by(url=url).first():
             db.session.add(NewsItem(title=title, url=url, summary=summary))
     db.session.commit()
+    old_items = (
+        NewsItem.query.order_by(NewsItem.created_at.desc())
+        .offset(25)
+        .all()
+    )
+    for item in old_items:
+        db.session.delete(item)
+    if old_items:
+        db.session.commit()
 
 if __name__ == "__main__":
     # Use an application context so SQLAlchemy can access the database


### PR DESCRIPTION
## Summary
- add Terms & Disclaimer page content
- move Terms link to discrete footer
- display retrieval date on News items
- limit stored news items to latest 25
- include placeholder image for terms page

## Testing
- `python -m py_compile app.py update_news.py daily_post.py freeze.py main.py update_site.py`
- `pip install -r requirements.txt`
- `python freeze.py`
- `python update_news.py`

------
https://chatgpt.com/codex/tasks/task_e_687d4f251b008333b8891f6bce53c9b0