### PR TITLE
Revise terms page text

### DIFF
--- a/app.py
+++ b/app.py
@@ -456,12 +456,11 @@ def create_tables():
         ),
         "terms": (
             "## Terms and Disclaimer\n"
-            "Personal information such as usernames and optional email addresses "
-            "is encrypted in our database using industry standard technology. "
-            "All courses and articles are offered free of charge. Certificates "
-            "are also free, though you may choose to contribute a small fee to help "
-            "support the site's operating costs. Providing an email lets us send "
-            "news and enables password recovery. We never share your data.\n\n"
+            "Any personal details you provide remain private and are used only to "
+            "run the site and send optional updates. All courses and articles are "
+            "offered free of charge. Certificates are also free, though you may "
+            "choose to contribute a small fee to help support the site's operating "
+            "costs. We never share your information.\n\n"
             "### Disclaimer\n"
             "Some content is generated with local AI models and may contain errors. "
             "Always consult qualified authorities when making important decisions."

--- a/docs/admin/index.html
+++ b/docs/admin/index.html
@@ -174,7 +174,7 @@ Yes. We periodically offer webinars and virtual Q&amp;A sessions with guest teac
   <input type="hidden" name="slug" value="terms">
   <h3>Terms</h3>
   <textarea name="content" class="form-control" rows="4">## Terms and Disclaimer
-Personal information such as usernames and optional email addresses is encrypted in our database using industry standard technology. All courses and articles are offered free of charge. Certificates are also free, though you may choose to contribute a small fee to help support the site&#39;s operating costs. Providing an email lets us send news and enables password recovery. We never share your data.
+Any personal details you provide remain private and are used only to run the site and send optional updates. All courses and articles are offered free of charge. Certificates are also free, though you may choose to contribute a small fee to help support the site&#39;s operating costs. We never share your information.
 
 ### Disclaimer
 Some content is generated with local AI models and may contain errors. Always consult qualified authorities when making important decisions.</textarea>

--- a/docs/terms/index.html
+++ b/docs/terms/index.html
@@ -31,7 +31,7 @@
   
   <h1 data-aos="fade-down">Terms</h1>
   <div data-aos="fade-up"><h2>Terms and Disclaimer</h2>
-<p>Personal information such as usernames and optional email addresses is encrypted in our database using industry standard technology. All courses and articles are offered free of charge. Certificates are also free, though you may choose to contribute a small fee to help support the site's operating costs. Providing an email lets us send news and enables password recovery. We never share your data.</p>
+<p>Any personal details you provide remain private and are used only to run the site and send optional updates. All courses and articles are offered free of charge. Certificates are also free, though you may choose to contribute a small fee to help support the site's operating costs. We never share your information.</p>
 <h3>Disclaimer</h3>
 <p>Some content is generated with local AI models and may contain errors. Always consult qualified authorities when making important decisions.</p></div>
   <img src="../static/terms.jpg" alt="Terms image" class="img-fluid my-4" data-aos="zoom-in">


### PR DESCRIPTION
## Summary
- update default Terms page wording in `create_tables`
- remove references to encryption and password recovery in static HTML

## Testing
- `python -m py_compile app.py daily_post.py freeze.py main.py update_news.py update_site.py`

------
https://chatgpt.com/codex/tasks/task_e_687d551122d0833390183b269ffe2bd9