### PR TITLE
Fix env mismatch for admin push

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import sys
 from io import BytesIO
 import smtplib
 from email.message import EmailMessage
@@ -890,7 +891,7 @@ def admin():
                 page.content = content
                 db.session.commit()
         elif action == "push":
-            subprocess.run(["python", "freeze.py"], check=True)
+            subprocess.run([sys.executable, "freeze.py"], check=True)
             subprocess.run(["git", "add", "docs"], check=True)
             msg = f"Update site {datetime.date.today().isoformat()}"
             subprocess.run(["git", "commit", "-m", msg])

--- a/update_site.py
+++ b/update_site.py
@@ -1,10 +1,12 @@
 import datetime
 import subprocess
 
+import sys
+
 COMMANDS = [
-    ['python', 'daily_post.py'],
-    ['python', 'update_news.py'],
-    ['python', 'freeze.py'],
+    [sys.executable, 'daily_post.py'],
+    [sys.executable, 'update_news.py'],
+    [sys.executable, 'freeze.py'],
 ]
 
 def run(cmd):


### PR DESCRIPTION
## Summary
- call subprocesses using `sys.executable` to keep the same Python environment
- update helper script so scheduled tasks run under the invoking interpreter

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python freeze.py`

------
https://chatgpt.com/codex/tasks/task_e_687e76e0ecf88333aa495e79a8c54764