### PR TITLE
Add batch course creation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It uses the local Llama 3 model (via [Ollama](https://github.com/ollama/ollama))
 - Optional `update_site.py` script can generate posts, update the news section
   and freeze the site. It no longer pushes updates automatically so the site is
   only published when you manually push changes.
+- `batch_courses.py` can generate multiple courses in one run.
 - Login and admin pages are only available when the environment variable
   `SHOW_LOGIN=1` is set while running the Flask app. They are excluded from the
   static site, so visitors on GitHub Pages will never see the login button.
@@ -44,6 +45,10 @@ It uses the local Llama 3 model (via [Ollama](https://github.com/ollama/ollama))
 6. (Optional) Automatically create posts, freeze the site and push updates:
    ```bash
    python update_site.py
+   ```
+7. (Optional) Generate several courses at once:
+   ```bash
+   python batch_courses.py "Jewish history" --courses 3 --modules 5
    ```
 
 The application uses a SQLite database (`site.db`) created automatically on first run.

--- a/batch_courses.py
+++ b/batch_courses.py
@@ -1,0 +1,31 @@
+"""Batch course creation script."""
+import argparse
+from app import app, create_tables, generate_course_topics, create_course
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate multiple courses using the local AI model"
+    )
+    parser.add_argument("topic", help="General subject for suggested courses")
+    parser.add_argument("--courses", type=int, default=3, help="Number of courses to create")
+    parser.add_argument("--modules", type=int, default=3, help="Number of modules per course")
+    parser.add_argument("--difficulty", default="Beginner", help="Difficulty level for all courses")
+    parser.add_argument("--prerequisites", default="", help="Prerequisites text for all courses")
+    args = parser.parse_args()
+
+    with app.app_context():
+        create_tables()
+        titles = generate_course_topics(args.topic, args.courses)
+        for title in titles:
+            course = create_course(
+                title,
+                module_count=args.modules,
+                difficulty=args.difficulty,
+                prerequisites=args.prerequisites,
+            )
+            print(f"Created course '{course.title}' (id {course.id})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `batch_courses.py` script to generate multiple courses automatically
- support generating course topics and creating courses programmatically
- update README with instructions for batch generation

## Testing
- `python -m py_compile app.py batch_courses.py`
- `python -m py_compile daily_post.py update_news.py update_site.py batch_courses.py`

------
https://chatgpt.com/codex/tasks/task_e_6886ae57ffd0833390232fc761191d0f