### PR TITLE
Add danger button for AI cleanup

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,7 +84,11 @@ class Course(db.Model):
 
 class CourseSection(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    course_id = db.Column(db.Integer, db.ForeignKey("course.id"), nullable=False)
+    course_id = db.Column(
+        db.Integer,
+        db.ForeignKey("course.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     title = db.Column(db.String(200), nullable=False)
     content = db.Column(db.Text, nullable=False)
     question = db.Column(db.Text)
@@ -92,13 +96,22 @@ class CourseSection(db.Model):
     order = db.Column(db.Integer)
 
     course = db.relationship(
-        "Course", backref=db.backref("sections", order_by="CourseSection.order")
+        "Course",
+        backref=db.backref(
+            "sections",
+            order_by="CourseSection.order",
+            cascade="all, delete-orphan",
+        ),
     )
 
 
 class QuizQuestion(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    course_id = db.Column(db.Integer, db.ForeignKey("course.id"), nullable=False)
+    course_id = db.Column(
+        db.Integer,
+        db.ForeignKey("course.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     question = db.Column(db.Text, nullable=False)
     option_a = db.Column(db.String(200))
     option_b = db.Column(db.String(200))
@@ -108,7 +121,12 @@ class QuizQuestion(db.Model):
     order = db.Column(db.Integer)
 
     course = db.relationship(
-        "Course", backref=db.backref("quiz_questions", order_by="QuizQuestion.order")
+        "Course",
+        backref=db.backref(
+            "quiz_questions",
+            order_by="QuizQuestion.order",
+            cascade="all, delete-orphan",
+        ),
     )
 
 
@@ -953,6 +971,12 @@ def admin():
         elif action == "delete_news":
             item = NewsItem.query.get_or_404(request.form.get("id"))
             db.session.delete(item)
+            db.session.commit()
+        elif action == "clear_ai_content":
+            BlogPost.query.delete()
+            NewsItem.query.delete()
+            for course in Course.query.all():
+                db.session.delete(course)
             db.session.commit()
         elif action == "update_settings":
             set_setting("site_topic", request.form.get("site_topic", "").strip())

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -243,6 +243,21 @@
       </div>
     </div>
   </div>
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="headingDanger">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseDanger" aria-expanded="false" aria-controls="collapseDanger">
+        Danger Zone
+      </button>
+    </h2>
+    <div id="collapseDanger" class="accordion-collapse collapse" aria-labelledby="headingDanger" data-bs-parent="#adminAccordion">
+      <div class="accordion-body">
+        <form method="post" onsubmit="return confirm('Delete all AI generated content?');">
+          <input type="hidden" name="action" value="clear_ai_content">
+          <button class="btn btn-danger" type="submit">Delete All AI Content</button>
+        </form>
+      </div>
+    </div>
+  </div>
 </div>
 <form method="post" class="mb-4 show-spinner">
   <input type="hidden" name="action" value="push">


### PR DESCRIPTION
## Summary
- add new `clear_ai_content` admin action to wipe all AI content
- add Danger Zone UI section with button to remove Blog posts, News and Courses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887b06c66208333aae0b524675d466b