### PR TITLE
Fix freeze and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ the site in one command. It leaves the updated files in your repository so you
 can review them and push when ready using the admin "Push to GitHub" button (or
 your own `git` commands).
 
+If the button fails or you prefer the command line, run:
+
+```bash
+python freeze.py
+git add docs
+git commit -m "Update site"
+git push
+```
+
 Other static hosting platforms such as Netlify or Vercel can be used if you
 prefer. Any service capable of serving the generated `docs/` directory will
 work.

--- a/freeze.py
+++ b/freeze.py
@@ -36,10 +36,14 @@ def course_detail():
     for course in Course.query.all():
         yield {'course_id': course.id}
 
-@freezer.register_generator
-def certificate():
-    for course in Course.query.all():
-        yield {'course_id': course.id}
+
+# Certificate pages are only available for users who have completed a
+# course, so they rely on session state and cannot be generated
+# statically.  The corresponding generator previously attempted to
+# freeze ``/certificate/<course_id>/`` pages which resulted in a
+# ``403 FORBIDDEN`` error during the freeze process.  Removing this
+# generator avoids the error and mirrors the behaviour of the site,
+# where certificates are generated dynamically at runtime.
 
 
 @freezer.register_generator


### PR DESCRIPTION
## Summary
- stop freezing certificate pages to avoid 403 error
- explain manual push commands in the README

## Testing
- `python freeze.py >/tmp/freeze.log 2>&1 && tail -n 20 /tmp/freeze.log`

------
https://chatgpt.com/codex/tasks/task_e_688985621e288333b1669e83364039aa